### PR TITLE
Make sure focus points are valid

### DIFF
--- a/src/org/cyanogenmod/focal/CameraManager.java
+++ b/src/org/cyanogenmod/focal/CameraManager.java
@@ -918,6 +918,10 @@ public class CameraManager {
      * @param y The Y position of the focus point
      */
     public void setFocusPoint(int x, int y) {
+        if (x < -1000 || x > 1000 || y < -1000 || y > 1000) {
+            Log.e(TAG, "setFocusPoint: values are not ideal " + "x= " + x + " y= " + y);
+            return;
+        }
         Camera.Parameters params = getParameters();
 
         if (params != null && params.getMaxNumFocusAreas() > 0) {


### PR DESCRIPTION
A `RuntimeException` is thrown when you attempt to set the parameters of the camera after setting a new focus area, then zooming. I'm not sure how you'd like to handle this. I've only tested this on an HTC One.

To reproduce:
1: Open the app and gain a new focus area
2: Pinch and zoom in

I managed to track the error down to `setFocusPoint` in `CameraManager`. But like I said, not sure if you'd like to use this as a temporary fix or handle it in another manner.
