### PR TITLE
fixes

### DIFF
--- a/src/org/cyanogenmod/focal/CameraActivity.java
+++ b/src/org/cyanogenmod/focal/CameraActivity.java
@@ -1307,6 +1307,7 @@ public class CameraActivity extends Activity implements CameraManager.CameraRead
             // Adjust orientationCompensation for the native orientation of the device.
             Configuration config = getResources().getConfiguration();
             int rotation = getWindowManager().getDefaultDisplay().getRotation();
+            // TODO ???
             Util.getDisplayRotation(CameraActivity.this);
 
             boolean nativeLandscape = false;

--- a/src/org/cyanogenmod/focal/CameraActivity.java
+++ b/src/org/cyanogenmod/focal/CameraActivity.java
@@ -452,7 +452,13 @@ public class CameraActivity extends Activity implements CameraManager.CameraRead
             resetPicSphere();
         } else if (mCameraMode == CAMERA_MODE_PANO) {
             resetPanorama();
-        }
+        } 
+        //else if (mCameraMode == CAMERA_MODE_VIDEO){
+            // must release the camera
+            // to reset internals - at least on find5
+            mCamManager.pause();
+            mCamManager.resume();
+        //}
 
         mCameraMode = newMode;
 

--- a/src/org/cyanogenmod/focal/CameraActivity.java
+++ b/src/org/cyanogenmod/focal/CameraActivity.java
@@ -642,7 +642,7 @@ public class CameraActivity extends Activity implements CameraManager.CameraRead
                     Log.e(TAG, "No preview size!! Something terribly wrong with camera!");
                     return;
                 }
-                mCamManager.setPreviewSize(sz.width, sz.height);
+                //mCamManager.setPreviewSize(sz.width, sz.height);
 
                 if (mIsCamSwitching) {
                     mCamManager.restartPreviewIfNeeded();

--- a/src/org/cyanogenmod/focal/CameraManager.java
+++ b/src/org/cyanogenmod/focal/CameraManager.java
@@ -412,6 +412,8 @@ public class CameraManager {
         
             Point sz = new Point(width, height);
             if (sz.equals(mPreviewSize)){
+                // must be done always
+                mPreview.notifyPreviewSize(mPreviewSize.x, mPreviewSize.y);
                 return;
             }
             mPreviewSize = sz;

--- a/src/org/cyanogenmod/focal/SnapshotManager.java
+++ b/src/org/cyanogenmod/focal/SnapshotManager.java
@@ -539,7 +539,8 @@ public class SnapshotManager {
         mProfile = profile;
 
         if (CameraActivity.getCameraMode() == CameraActivity.CAMERA_MODE_VIDEO) {
-            mCameraManager.setPreviewSize(profile.videoFrameWidth, profile.videoFrameHeight);
+            // TODO: setVideoSize is handling preview changing
+            mCameraManager.setVideoSize(profile.videoFrameWidth, profile.videoFrameHeight);
         }
     }
 

--- a/src/org/cyanogenmod/focal/SnapshotManager.java
+++ b/src/org/cyanogenmod/focal/SnapshotManager.java
@@ -535,6 +535,10 @@ public class SnapshotManager {
         return mImageSaver;
     }
 
+    public CamcorderProfile getVideoProfile(){
+        return mProfile;
+    }
+    
     public void setVideoProfile(final CamcorderProfile profile) {
         mProfile = profile;
 

--- a/src/org/cyanogenmod/focal/widgets/SettingsWidget.java
+++ b/src/org/cyanogenmod/focal/widgets/SettingsWidget.java
@@ -47,7 +47,7 @@ import java.util.List;
  * Overflow settings widget
  */
 public class SettingsWidget extends WidgetBase {
-    private static final String TAG = "CameraManager";
+    private static final String TAG = "SettingsWidget";
 
     private static final String DRAWABLE_KEY_EXPO_RING = "_Nemesis_ExposureRing=true";
     private static final String DRAWABLE_KEY_AUTO_ENHANCE = "_Nemesis_AutoEnhance=true";
@@ -191,12 +191,12 @@ public class SettingsWidget extends WidgetBase {
                 @Override
                 public void onClick(DialogInterface dialogInterface, int i) {
                     mInitialOrientation = -1;
-                    Camera.Size size = mResolutions.get(mNumberPicker.getValue());
 
                     if (CameraActivity.getCameraMode() == CameraActivity.CAMERA_MODE_PHOTO
                             || CameraActivity.getCameraMode()
                             == CameraActivity.CAMERA_MODE_PICSPHERE) {
                         // Set picture size
+                        Camera.Size size = mResolutions.get(mNumberPicker.getValue());
                         // TODO: only one method
                         mCamManager.setPictureSize(""+size.width+"x"+size.height);
 
@@ -212,9 +212,15 @@ public class SettingsWidget extends WidgetBase {
                         }
                     } else if (CameraActivity.getCameraMode() == CameraActivity.CAMERA_MODE_VIDEO) {
                         // Set video size
-                        applyVideoResolution(mVideoResolutions.get(mNumberPicker.getValue()));
+                        String size = mVideoResolutions.get(mNumberPicker.getValue());
+                        applyVideoResolution(size);
+                        
+                        String[] splat = size.split("x");
+                        int width = Integer.parseInt(splat[0]);
+                        int height = Integer.parseInt(splat[1]);
+
                         SettingsStorage.storeCameraSetting(mContext, mCamManager.getCurrentFacing(),
-                                "video-size", ""+size.width+"x"+size.height);
+                                "video-size", ""+width+"x"+height);
                     }
                 }
             });

--- a/src/org/cyanogenmod/focal/widgets/SettingsWidget.java
+++ b/src/org/cyanogenmod/focal/widgets/SettingsWidget.java
@@ -26,6 +26,8 @@ import android.media.CamcorderProfile;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.NumberPicker;
+import android.util.Log;
+import android.graphics.Point;
 
 import org.cyanogenmod.focal.CameraActivity;
 import org.cyanogenmod.focal.CameraCapabilities;
@@ -33,6 +35,7 @@ import org.cyanogenmod.focal.CameraManager;
 import fr.xplod.focal.R;
 import org.cyanogenmod.focal.SettingsStorage;
 import org.cyanogenmod.focal.SnapshotManager;
+import org.cyanogenmod.focal.Util;
 
 import java.text.DecimalFormat;
 import java.util.ArrayList;
@@ -44,6 +47,8 @@ import java.util.List;
  * Overflow settings widget
  */
 public class SettingsWidget extends WidgetBase {
+    private static final String TAG = "CameraManager";
+
     private static final String DRAWABLE_KEY_EXPO_RING = "_Nemesis_ExposureRing=true";
     private static final String DRAWABLE_KEY_AUTO_ENHANCE = "_Nemesis_AutoEnhance=true";
     private static final String DRAWABLE_KEY_RULE_OF_THIRDS = "_Nemesis_RuleOfThirds=true";
@@ -200,6 +205,7 @@ public class SettingsWidget extends WidgetBase {
                                     .getCurrentFacing(), "picture-size",
                                     ""+size.width+"x"+size.height);
                         } else {
+                            // TODO: should changing be possible for pic sphere???
                             SettingsStorage.storeCameraSetting(mContext,
                                     mCamManager.getCurrentFacing(), "picsphere-picture-size",
                                     ""+size.width+"x"+size.height);
@@ -226,7 +232,7 @@ public class SettingsWidget extends WidgetBase {
         mCapabilities = capabilities;
 
         CameraManager cam = context.getCamManager();
-
+        Log.d(TAG, "SettingsWidget -- start");
         getToggleButton().setHintText(R.string.widget_settings);
 
         if (CameraActivity.getCameraMode() == CameraActivity.CAMERA_MODE_PHOTO
@@ -257,8 +263,12 @@ public class SettingsWidget extends WidgetBase {
                         mCamManager.getCurrentFacing(), "picture-size", ""+mResolutions
                         .get(0).width+"x"+mResolutions.get(0).height);
             } else {
+                // TODO: moved from setCameraMode
+                Point picSphereSize = Util.findBestPicSpherePictureSize(
+                        mCamManager.getParameters().getSupportedPictureSizes(), true);
                 resolution = SettingsStorage.getCameraSetting(context,
-                        mCamManager.getCurrentFacing(), "picsphere-picture-size", "640x480");
+                        mCamManager.getCurrentFacing(), "picsphere-picture-size", 
+                        "" + picSphereSize.x + "x" + picSphereSize.y);
             }
             mCamManager.setPictureSize(resolution);
         } else if (CameraActivity.getCameraMode() == CameraActivity.CAMERA_MODE_VIDEO) {
@@ -300,8 +310,13 @@ public class SettingsWidget extends WidgetBase {
             String resolution = SettingsStorage.getCameraSetting(context,
                         mCamManager.getCurrentFacing(), "video-size", mVideoResolutions.get(0));
             applyVideoResolution(resolution);
+        } else if (CameraActivity.getCameraMode() == CameraActivity.CAMERA_MODE_PANO) {
+            // TODO: Apply special settings for panorama mode
+            // use the same "workflow" as for other modes
+            // only the SettingsWidget will set the correct preview
+            mCamManager.initializePanoramaMode();
         }
-
+        
         mResolutionButton = new WidgetOptionButton(
                 R.drawable.ic_widget_settings_resolution, context);
         mResolutionButton.setOnClickListener(mResolutionClickListener);
@@ -377,6 +392,7 @@ public class SettingsWidget extends WidgetBase {
             }
         });
         addViewToContainer(mToggleWidgetsButton);
+        Log.d(TAG, "SettingsWidget -- stop");
     }
 
     @Override

--- a/src/org/cyanogenmod/focal/widgets/SettingsWidget.java
+++ b/src/org/cyanogenmod/focal/widgets/SettingsWidget.java
@@ -133,7 +133,6 @@ public class SettingsWidget extends WidgetBase {
         public void onClick(View view) {
             mInitialOrientation = -1;
 
-            Camera.Size actualSz = mCamManager.getParameters().getPictureSize();
             mNumberPicker = new NumberPicker(mContext);
             String[] names = new String[mResolutionsName.size()];
             mResolutionsName.toArray(names);
@@ -155,11 +154,25 @@ public class SettingsWidget extends WidgetBase {
                 }
             });
 
-            if (mResolutions != null) {
-                for (int i = 0; i < mResolutions.size(); i++) {
-                    if (mResolutions.get(i).equals(actualSz)) {
-                        mNumberPicker.setValue(i);
-                        break;
+            if (CameraActivity.getCameraMode() == CameraActivity.CAMERA_MODE_VIDEO){
+                // TODO set correct menu selection also for video
+                String actualSz = getActualProfileResolution();
+                if (mVideoResolutions != null) {
+                    for (int i = 0; i < mVideoResolutions.size(); i++) {
+                        if (mVideoResolutions.get(i).equals(actualSz)) {
+                            mNumberPicker.setValue(i);
+                            break;
+                        }
+                    }
+                }
+            } else {
+                Camera.Size actualSz = mCamManager.getParameters().getPictureSize();
+                if (mResolutions != null) {
+                    for (int i = 0; i < mResolutions.size(); i++) {
+                        if (mResolutions.get(i).equals(actualSz)) {
+                            mNumberPicker.setValue(i);
+                            break;
+                        }
                     }
                 }
             }
@@ -406,6 +419,11 @@ public class SettingsWidget extends WidgetBase {
             mContext.getSnapManager().setVideoProfile(
                     CamcorderProfile.get(CamcorderProfile.QUALITY_CIF));
         }
+    }
+
+    private String getActualProfileResolution() {
+        CamcorderProfile actualProfile = mContext.getSnapManager().getVideoProfile();
+        return "" + actualProfile.videoFrameWidth + "x" + actualProfile.videoFrameHeight;
     }
 
     private void openWidgetsToggleDialog() {

--- a/src/org/cyanogenmod/focal/widgets/SettingsWidget.java
+++ b/src/org/cyanogenmod/focal/widgets/SettingsWidget.java
@@ -179,7 +179,8 @@ public class SettingsWidget extends WidgetBase {
                             || CameraActivity.getCameraMode()
                             == CameraActivity.CAMERA_MODE_PICSPHERE) {
                         // Set picture size
-                        mCamManager.setPictureSize(size);
+                        // TODO: only one method
+                        mCamManager.setPictureSize(""+size.width+"x"+size.height);
 
                         if (CameraActivity.getCameraMode() == CameraActivity.CAMERA_MODE_PHOTO) {
                             SettingsStorage.storeCameraSetting(mContext, mCamManager
@@ -281,6 +282,11 @@ public class SettingsWidget extends WidgetBase {
                 mResolutionsName.add(mContext.getString(R.string.video_res_480p));
                 mVideoResolutions.add("720x480");
             }
+
+            // TODO: Restore video size if we have any
+            String resolution = SettingsStorage.getCameraSetting(context,
+                        mCamManager.getCurrentFacing(), "video-size", mVideoResolutions.get(0));
+            applyVideoResolution(resolution);
         }
 
         mResolutionButton = new WidgetOptionButton(


### PR DESCRIPTION
Just take a look - I have commented all my changes with TODO
I have tried to fix the preview size handling for photo and video mode
changing picture size also requires a preview restart. 
There are still a few open issues e.g. the preview is streched in 16:9 resolutions
and I dont really understand how that works :)

The second one is to set the correct menu selection for the current
video resolution in the settings widget

This preview handling makes me crazy :)
All of this is still WIP. My goal was to move all preview handling into the
SettingsWidget now. So only from there the preview size can be changed.
There are still some issues with preview aspect ratios  if you switch the 
video resolution and then forth and back between the different modes

Third one contains one important fix
Check mVideoRotation - this and using mMediaRecorder.setOrientationHint(mVideoRotation);
fixes the wrong video orientation of recorded videos
