### PR TITLE
Fix Hungarian translations.

### DIFF
--- a/res/values-hu/arrays.xml
+++ b/res/values-hu/arrays.xml
@@ -29,7 +29,7 @@
         <item>Automatikus</item>
         <item>Letiltva</item>
         <item>Engedélyezve</item>
-        <item>Vaku</item>
+        <item>Zseblámpa</item>
         <item>Vörösszem csökkentés</item>
     </string-array>
     <string-array name="widget_effects_hints">

--- a/res/values-hu/strings.xml
+++ b/res/values-hu/strings.xml
@@ -58,7 +58,7 @@
     <string name="widget_effect">Színhatások</string>
     <string name="widget_enhancements">Színfokozás</string>
     <string name="widget_exposure_compensation">Expo korrekció</string>
-    <string name="widget_flash">Zseblámpa</string>
+    <string name="widget_flash">Vaku</string>
     <string name="widget_hdr">HDR</string>
     <string name="widget_iso">ISO érzékenység</string>
     <string name="widget_scenemode">Kép jellege</string>


### PR DESCRIPTION
Zseblámpa (flashlight) and Vaku (flash) were mixed up.
